### PR TITLE
Add kill switch

### DIFF
--- a/C Sharp Source/LabVIEW CLI/LabVIEW CLI.sln
+++ b/C Sharp Source/LabVIEW CLI/LabVIEW CLI.sln
@@ -7,7 +7,6 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LabVIEW CLI", "LabVIEW CLI.
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{143D8C52-C4CF-4B9A-9699-71B466D7CF0A}"
 	ProjectSection(SolutionItems) = preProject
-		cliOptions.cs = cliOptions.cs
 		..\..\README.md = ..\..\README.md
 	EndProjectSection
 EndProject

--- a/C Sharp Source/LabVIEW CLI/LvLauncher.cs
+++ b/C Sharp Source/LabVIEW CLI/LvLauncher.cs
@@ -18,6 +18,7 @@ namespace LabVIEW_CLI
         private ManualResetEventSlim lvStarted = new ManualResetEventSlim();
 
         public int ProcessId { get; private set; }
+        public ManualResetEventSlim lvExited = new ManualResetEventSlim();
 
 
         public event EventHandler Exited;
@@ -96,6 +97,7 @@ namespace LabVIEW_CLI
         private void Process_Exited(object sender, EventArgs e)
         {
             output.writeInfo("LabVIEW exiting...");
+            lvExited.Set();
             Exited?.Invoke(sender, e);
         }
 

--- a/C Sharp Source/LabVIEW CLI/Program.cs
+++ b/C Sharp Source/LabVIEW CLI/Program.cs
@@ -136,7 +136,20 @@ namespace LabVIEW_CLI
 
             } while (!stop);
 
+            // close tcp listener
             lvInterface.Close();
+
+            // if killswitch is set, force LabVIEW to exit if it has not closed by itself after a 10s timeout (or the period specified in --timeout)
+            if (options.kill)
+            {
+                int timeout = options.timeout == -1 ? 10000 : options.timeout;
+                if (!launcher.lvExited.Wait(timeout))
+                {
+                    output.writeMessage("Forcing LabVIEW to terminate...");
+                    launcher.Kill();
+                }
+            }
+
             return exitCode;
         }
 

--- a/C Sharp Source/LabVIEW CLI/Properties/AssemblyInfo.cs
+++ b/C Sharp Source/LabVIEW CLI/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.3.1.1")]
-[assembly: AssemblyFileVersion("1.3.1.1")]
+[assembly: AssemblyVersion("1.4.0.0")]
+[assembly: AssemblyFileVersion("1.4.0.0")]

--- a/C Sharp Source/LabVIEW CLI/cliOptions.cs
+++ b/C Sharp Source/LabVIEW CLI/cliOptions.cs
@@ -36,6 +36,10 @@ namespace LabVIEW_CLI
         HelpText = "Maximum time (in ms) to wait for the LabVIEW program to connect to the cli. -1 = Infinity")]
         public int timeout { get; set; }
 
+        [Option("kill", DefaultValue = false,
+        HelpText = "Forces the LabVIEW process to exit after the CLI receives a return code/error")]
+        public bool kill { get; set; }
+
         [ValueOption(0)]
         public string LaunchVI { get; set; }
 

--- a/README.md
+++ b/README.md
@@ -31,4 +31,6 @@ last argument (or last before -- if user arguments) is what to launch.
 
 --timeout: Maximum time (in ms) to wait for the LabVIEW program to connect to the CLI (-1 = Infinity).
 
+--kill: Forces the LabVIEW process to exit after the CLI receives a return code/error
+
 Any arguments after -- are passed to the application.


### PR DESCRIPTION
I added an option to kill LabVIEW after a short timeout if it doesn't exit by itself after receiving a return code or a read error.

When I run LabVIEW builds from my CI system, LabVIEW often does not close after sending a return code.
I suspect this happens because of a "Unsaved Changes" Dialog, which you cannot see because LabVIEW is beeing executed by a service running in system space.
If LabVIEW does not terminate, the following build will fail instantly.

By killing LabVIEW, the CI system works much more stable....
