### PR TITLE
Fixes issue #40.  

### DIFF
--- a/C Sharp Source/LabVIEW CLI/LvLauncher.cs
+++ b/C Sharp Source/LabVIEW CLI/LvLauncher.cs
@@ -103,7 +103,7 @@ namespace LabVIEW_CLI
 
         private Boolean isExe(String launchPath)
         {
-            return System.Text.RegularExpressions.Regex.IsMatch(launchPath, ".exe$");
+            return System.Text.RegularExpressions.Regex.IsMatch(launchPath, ".exe$", System.Text.RegularExpressions.RegexOptions.IgnoreCase);
         }
 
         private void Process_Exited(object sender, EventArgs e)


### PR DESCRIPTION
.exe target application are now recognized as executable even if the .EXE extension is in uppercase in the command line.

Ex: labview-cli TARGETAPP.EXE